### PR TITLE
Windows fixes for scripts

### DIFF
--- a/configure
+++ b/configure
@@ -62,7 +62,7 @@ def configure_meson(args):
     os.chdir(build_dir)
 
     try:
-        subprocess.check_call([meson, "../"] + args + get_configs(meson))
+        subprocess.check_call([sys.executable, meson, "../"] + args + get_configs(meson))
     except subprocess.CalledProcessError as e:
         print("EXIT meson return %s" % e.returncode)
         exit(1)

--- a/gst-uninstalled.py
+++ b/gst-uninstalled.py
@@ -123,7 +123,10 @@ if __name__ == "__main__":
         exit(1)
 
     if not args:
-        args = [os.environ.get("SHELL", os.path.realpath("/bin/sh"))]
+        if os.name is 'nt':
+            args = [os.environ.get("COMSPEC", r"C:\WINDOWS\system32\cmd.exe")]
+        else:
+            args = [os.environ.get("SHELL", os.path.realpath("/bin/sh"))]
         if args[0] == "/bin/bash":
             args.append("--noprofile")
 


### PR DESCRIPTION
subprocess.call runs programs directly when shell=False and can't
take advantage of the association that makes python scripts
executable in shells, so explicitly add the interpreter to the
args for call.

Run the windows command prompt by default in gst-uninstalled.
